### PR TITLE
Add fix for MSVC 'no std::min/max' error

### DIFF
--- a/src/GridShape.cpp
+++ b/src/GridShape.cpp
@@ -1,4 +1,5 @@
 #include "generator/GridShape.hpp"
+#include <algorithm>
 
 using namespace generator;
 


### PR DESCRIPTION
As far as I can tell, this project won't compile in Visual Studio without adding a reference to \<algorithm\> in the file that uses std::min and std::max.